### PR TITLE
A more flexible API to release memory to the operating system

### DIFF
--- a/tcmalloc/internal_malloc_extension.h
+++ b/tcmalloc/internal_malloc_extension.h
@@ -90,6 +90,8 @@ ABSL_ATTRIBUTE_WEAK void MallocExtension_Internal_SetSkipSubreleaseInterval(
 ABSL_ATTRIBUTE_WEAK size_t MallocExtension_Internal_ReleaseCpuMemory(int cpu);
 ABSL_ATTRIBUTE_WEAK size_t
 MallocExtension_Internal_ReleaseMemoryToSystem(size_t bytes);
+ABSL_ATTRIBUTE_WEAK size_t
+MallocExtension_Internal_ReleaseMemoryToSystemEx(size_t bytes, bool force);
 ABSL_ATTRIBUTE_WEAK void MallocExtension_Internal_SetMemoryLimit(
     const tcmalloc::MallocExtension::MemoryLimit* limit);
 

--- a/tcmalloc/malloc_extension.cc
+++ b/tcmalloc/malloc_extension.cc
@@ -142,6 +142,15 @@ void MallocExtension::ReleaseMemoryToSystem(size_t num_bytes) {
 #endif
 }
 
+size_t MallocExtension::ReleaseMemoryToSystemEx(size_t num_bytes, bool force) {
+#if ABSL_INTERNAL_HAVE_WEAK_MALLOCEXTENSION_STUBS
+  if (&MallocExtension_Internal_ReleaseMemoryToSystemEx != nullptr) {
+    return MallocExtension_Internal_ReleaseMemoryToSystemEx(num_bytes, force);
+  }
+#endif
+  return 0;
+}
+
 AddressRegionFactory* MallocExtension::GetRegionFactory() {
 #if ABSL_INTERNAL_HAVE_WEAK_MALLOCEXTENSION_STUBS
   if (&MallocExtension_Internal_GetRegionFactory == nullptr) {

--- a/tcmalloc/malloc_extension.h
+++ b/tcmalloc/malloc_extension.h
@@ -394,6 +394,8 @@ class MallocExtension final {
   //   back in.
   static void ReleaseMemoryToSystem(size_t num_bytes);
 
+  static size_t ReleaseMemoryToSystemEx(size_t num_bytes, bool force);
+
   struct MemoryLimit {
     // Make a best effort attempt to prevent more than limit bytes of memory
     // from being allocated by the system. In particular, if satisfying a given

--- a/tcmalloc/tcmalloc.cc
+++ b/tcmalloc/tcmalloc.cc
@@ -316,9 +316,6 @@ extern "C" size_t MallocExtension_Internal_ReleaseMemoryToSystemEx(
   // memory at a constant rate.
   ABSL_CONST_INIT static size_t extra_bytes_released;
 
-  if (num_bytes == 0)
-    return 0;
-
   absl::base_internal::SpinLockHolder rh(&release_lock);
 
   absl::base_internal::SpinLockHolder h(&pageheap_lock);


### PR DESCRIPTION
Adding a new ReleaseMemoryToSystemEx with the following advantages over ReleaseMemoryToSystem:
- It returns the number of bytes actually released.
- It provides a "force" argument, allowing us to ignore previous excess release of memory to the system, and try to release the amount of memory requested. The logic to track excess release of memory might be confusing for an application's memory release loop.