### PR TITLE
Add option to not seed lifetime profiler with live allocations

### DIFF
--- a/tcmalloc/deallocation_profiler.cc
+++ b/tcmalloc/deallocation_profiler.cc
@@ -309,7 +309,7 @@ class DeallocationProfiler {
   std::unique_ptr<DeallocationStackTraceTable> reports_ = nullptr;
 
  public:
-  explicit DeallocationProfiler(DeallocationProfilerList* list, bool seed_with_live_allocs = true):
+  explicit DeallocationProfiler(DeallocationProfilerList* list, bool seed_with_live_allocs):
       list_(list) {
     reports_ = std::make_unique<DeallocationStackTraceTable>();
     list_->Add(this, seed_with_live_allocs);

--- a/tcmalloc/deallocation_profiler.cc
+++ b/tcmalloc/deallocation_profiler.cc
@@ -309,9 +309,10 @@ class DeallocationProfiler {
   std::unique_ptr<DeallocationStackTraceTable> reports_ = nullptr;
 
  public:
-  explicit DeallocationProfiler(DeallocationProfilerList* list) : list_(list) {
+  explicit DeallocationProfiler(DeallocationProfilerList* list, bool seed_with_live_allocs = true):
+      list_(list) {
     reports_ = std::make_unique<DeallocationStackTraceTable>();
-    list_->Add(this);
+    list_->Add(this, seed_with_live_allocs);
   }
 
   ~DeallocationProfiler() {
@@ -379,17 +380,19 @@ class DeallocationProfiler {
   }
 };
 
-void DeallocationProfilerList::Add(DeallocationProfiler* profiler) {
+void DeallocationProfilerList::Add(DeallocationProfiler* profiler, bool seed_with_live_allocs) {
   SpinLockHolder h(&profilers_lock_);
   profiler->next_ = first_;
   first_ = profiler;
 
-  // Whenever a new profiler is created, we seed it with live allocations.
-  tcmalloc_internal::tc_globals.sampled_allocation_recorder().Iterate(
-      [profiler](
-          const tcmalloc_internal::SampledAllocation& sampled_allocation) {
-        profiler->ReportMalloc(sampled_allocation.sampled_stack);
-      });
+  if (seed_with_live_allocs) {
+    // Whenever a new profiler is created, we seed it with live allocations.
+    tcmalloc_internal::tc_globals.sampled_allocation_recorder().Iterate(
+        [profiler](
+            const tcmalloc_internal::SampledAllocation& sampled_allocation) {
+          profiler->ReportMalloc(sampled_allocation.sampled_stack);
+        });
+  }
 }
 
 // This list is very short and we're nowhere near a hot path, just walk
@@ -559,8 +562,8 @@ void DeallocationProfiler::DeallocationStackTraceTable::Iterate(
   }
 }
 
-DeallocationSample::DeallocationSample(DeallocationProfilerList* list) {
-  profiler_ = std::make_unique<DeallocationProfiler>(list);
+DeallocationSample::DeallocationSample(DeallocationProfilerList* list, bool seed_with_live_allocs) {
+  profiler_ = std::make_unique<DeallocationProfiler>(list, seed_with_live_allocs);
 }
 
 tcmalloc::Profile DeallocationSample::Stop() && {

--- a/tcmalloc/deallocation_profiler.h
+++ b/tcmalloc/deallocation_profiler.h
@@ -47,7 +47,7 @@ class DeallocationProfilerList {
 class DeallocationSample final
     : public tcmalloc_internal::AllocationProfilingTokenBase {
  public:
-  explicit DeallocationSample(DeallocationProfilerList* list, bool seed_with_live_allocs = true);
+  explicit DeallocationSample(DeallocationProfilerList* list, bool seed_with_live_allocs);
   // We define the dtor to ensure it is placed in the desired text section.
   ~DeallocationSample() override = default;
 

--- a/tcmalloc/deallocation_profiler.h
+++ b/tcmalloc/deallocation_profiler.h
@@ -35,7 +35,7 @@ class DeallocationProfilerList {
 
   void ReportMalloc(const tcmalloc_internal::StackTrace& stack_trace);
   void ReportFree(tcmalloc_internal::AllocHandle handle);
-  void Add(DeallocationProfiler* profiler);
+  void Add(DeallocationProfiler* profiler, bool seed_with_live_allocs);
   void Remove(DeallocationProfiler* profiler);
 
  private:
@@ -47,7 +47,7 @@ class DeallocationProfilerList {
 class DeallocationSample final
     : public tcmalloc_internal::AllocationProfilingTokenBase {
  public:
-  explicit DeallocationSample(DeallocationProfilerList* list);
+  explicit DeallocationSample(DeallocationProfilerList* list, bool seed_with_live_allocs = true);
   // We define the dtor to ensure it is placed in the desired text section.
   ~DeallocationSample() override = default;
 

--- a/tcmalloc/internal_malloc_extension.h
+++ b/tcmalloc/internal_malloc_extension.h
@@ -67,7 +67,7 @@ MallocExtension_Internal_SnapshotCurrent(tcmalloc::ProfileType type);
 ABSL_ATTRIBUTE_WEAK tcmalloc::tcmalloc_internal::AllocationProfilingTokenBase*
 MallocExtension_Internal_StartAllocationProfiling();
 ABSL_ATTRIBUTE_WEAK tcmalloc::tcmalloc_internal::AllocationProfilingTokenBase*
-MallocExtension_Internal_StartLifetimeProfiling();
+MallocExtension_Internal_StartLifetimeProfiling(bool seed_with_live_allocs);
 
 ABSL_ATTRIBUTE_WEAK void MallocExtension_Internal_ActivateGuardedSampling();
 ABSL_ATTRIBUTE_WEAK tcmalloc::MallocExtension::Ownership

--- a/tcmalloc/malloc_extension.cc
+++ b/tcmalloc/malloc_extension.cc
@@ -195,7 +195,7 @@ MallocExtension::StartAllocationProfiling() {
 }
 
 MallocExtension::AllocationProfilingToken
-MallocExtension::StartLifetimeProfiling() {
+MallocExtension::StartLifetimeProfiling(bool seed_with_live_allocs) {
 #if ABSL_INTERNAL_HAVE_WEAK_MALLOCEXTENSION_STUBS
   if (&MallocExtension_Internal_StartLifetimeProfiling == nullptr) {
     return {};
@@ -203,7 +203,7 @@ MallocExtension::StartLifetimeProfiling() {
 
   return tcmalloc_internal::AllocationProfilingTokenAccessor::MakeToken(
       std::unique_ptr<tcmalloc_internal::AllocationProfilingTokenBase>(
-          MallocExtension_Internal_StartLifetimeProfiling()));
+          MallocExtension_Internal_StartLifetimeProfiling(seed_with_live_allocs)));
 #else
   return {};
 #endif

--- a/tcmalloc/malloc_extension.h
+++ b/tcmalloc/malloc_extension.h
@@ -549,7 +549,7 @@ class MallocExtension final {
 
   // Start recording lifetimes of objects live during this profiling
   // session. Returns null if the implementation does not support profiling.
-  static AllocationProfilingToken StartLifetimeProfiling();
+  static AllocationProfilingToken StartLifetimeProfiling(bool seed_with_live_allocs = true);
 
   // Runs housekeeping actions for the allocator off of the main allocation path
   // of new/delete.  As of 2020, this includes:

--- a/tcmalloc/malloc_extension.h
+++ b/tcmalloc/malloc_extension.h
@@ -549,7 +549,7 @@ class MallocExtension final {
 
   // Start recording lifetimes of objects live during this profiling
   // session. Returns null if the implementation does not support profiling.
-  static AllocationProfilingToken StartLifetimeProfiling(bool seed_with_live_allocs = true);
+  static AllocationProfilingToken StartLifetimeProfiling(bool seed_with_live_allocs);
 
   // Runs housekeeping actions for the allocator off of the main allocation path
   // of new/delete.  As of 2020, this includes:

--- a/tcmalloc/profile_test.cc
+++ b/tcmalloc/profile_test.cc
@@ -124,7 +124,7 @@ TEST(DeallocationSampleTest, RaceToClaim) {
     counter.DecrementCount();
 
     while (!stop) {
-      auto token = MallocExtension::StartLifetimeProfiling();
+      auto token = MallocExtension::StartLifetimeProfiling(true);
       absl::SleepFor(absl::Microseconds(1));
       auto profile = std::move(token).Stop();
     }

--- a/tcmalloc/tcmalloc.cc
+++ b/tcmalloc/tcmalloc.cc
@@ -245,9 +245,9 @@ MallocExtension_Internal_StartAllocationProfiling() {
 }
 
 extern "C" tcmalloc_internal::AllocationProfilingTokenBase*
-MallocExtension_Internal_StartLifetimeProfiling() {
+MallocExtension_Internal_StartLifetimeProfiling(bool seed_with_live_allocs) {
   return new deallocationz::DeallocationSample(
-      &tc_globals.deallocation_samples);
+      &tc_globals.deallocation_samples, seed_with_live_allocs);
 }
 
 MallocExtension::Ownership GetOwnership(const void* ptr) {

--- a/tcmalloc/testing/deallocation_profiler_test.cc
+++ b/tcmalloc/testing/deallocation_profiler_test.cc
@@ -84,7 +84,7 @@ TEST(LifetimeProfiler, BasicCounterValues) {
 
   void *ptr = nullptr;
 
-  auto token = tcmalloc::MallocExtension::StartLifetimeProfiling();
+  auto token = tcmalloc::MallocExtension::StartLifetimeProfiling(true);
 
   // Perform four allocation/deallocation pairs. The first batch should get
   // merged into one sample, the second batch into two different samples.
@@ -195,7 +195,7 @@ TEST(LifetimeProfiler, RecordLiveAllocations) {
   void *ptr = SingleAlloc(kAllocFrames, kMallocSize);
   absl::SleepFor(kDuration);
 
-  auto token = tcmalloc::MallocExtension::StartLifetimeProfiling();
+  auto token = tcmalloc::MallocExtension::StartLifetimeProfiling(true);
   SingleDealloc(kDeallocFrames, ptr);
   const tcmalloc::Profile profile = std::move(token).Stop();
 
@@ -252,7 +252,7 @@ TEST(LifetimeProfiler, RecordCensoredAllocations) {
   // Allocated prior to profiling.
   void *ptr1 = SingleAlloc(kAllocFrames, kMallocSize1);
 
-  auto token = tcmalloc::MallocExtension::StartLifetimeProfiling();
+  auto token = tcmalloc::MallocExtension::StartLifetimeProfiling(true);
 
   // Change the requested size so that it always shows up as a different sample.
   void *ptr2 = SingleAlloc(kAllocFrames, kMallocSize2);


### PR DESCRIPTION
The lifetime profiler is used for pprof/heap to examine allocations in a fixed time window. But, it is seeded with live sampled objects (those that have not been deleted) when it is created. This obfuscates the output with existing allocations. We should have a way to not seed the lifetime allocator with live allocations.