### PR TITLE
Remove a redundant definition (LifetimeDatabase::kMaxStackDepth)

### DIFF
--- a/tcmalloc/internal/lifetime_predictions.h
+++ b/tcmalloc/internal/lifetime_predictions.h
@@ -176,7 +176,6 @@ class LifetimeDatabase {
   }
 
  protected:
-  static const int kMaxStackDepth = 64;
 
   static absl::base_internal::LowLevelAlloc::Arena* GetArena() {
     static absl::base_internal::LowLevelAlloc::Arena* arena =


### PR DESCRIPTION
To fix this compilation error on GCC 13: https://gist.githubusercontent.com/mbautin/e4dc0e1286b24daab4c9882534faa120/raw