### PR TITLE
Move DeallocationSample destructor to .cc file

### DIFF
--- a/tcmalloc/deallocation_profiler.cc
+++ b/tcmalloc/deallocation_profiler.cc
@@ -720,6 +720,8 @@ DeallocationSample::DeallocationSample(DeallocationProfilerList* list, bool seed
   profiler_ = std::make_unique<DeallocationProfiler>(list, seed_with_live_allocs);
 }
 
+DeallocationSample::~DeallocationSample() = default;
+
 tcmalloc::Profile DeallocationSample::Stop() && {
   if (profiler_ != nullptr) {
     tcmalloc::Profile profile = profiler_->Stop();

--- a/tcmalloc/deallocation_profiler.h
+++ b/tcmalloc/deallocation_profiler.h
@@ -50,7 +50,7 @@ class DeallocationSample final
  public:
   explicit DeallocationSample(DeallocationProfilerList* list, bool seed_with_live_allocs);
   // We define the dtor to ensure it is placed in the desired text section.
-  ~DeallocationSample() override = default;
+  ~DeallocationSample() override;
 
   tcmalloc::Profile Stop() && override;
 


### PR DESCRIPTION
DeallocationSample holds a std::unique_ptr to a forward-declared class that is defined in the corresponding .cc file (similar to pimpl). Definining the destructor inline in the header is problematic since std::unique_ptr destructor requires the class to be defined, not just declared. This appears as a compile failure when compiling with clang 17/19 and --std=c++23.

This change moves the destructor definition into the source file.